### PR TITLE
Change website title

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,7 +3,7 @@
 
 PATH = 'content'
 AUTHOR = u'OSU Open Source Lab'
-SITENAME = u'Beaver Barcamp 16'
+SITENAME = u'Beaver Barcamp 17'
 SITEURL = 'http://beaverbarcamp.org'
 
 TIMEZONE = 'US/Pacific'


### PR DESCRIPTION
@osuosl/web-reviewers Last change for now: the title of the website needs to say BarCamp 17, not BarCamp 16. Let me know if you see any issues.