### PR TITLE
Default to using https, enable relative URLs

### DIFF
--- a/publishconf.py
+++ b/publishconf.py
@@ -12,7 +12,7 @@ SITEURL = ''
 # Following items are often useful when publishing
 
 # Uncomment following line for absolute URLs in production:
-#RELATIVE_URLS = False
+RELATIVE_URLS = False
 
 #DISQUS_SITENAME = ""
 #GOOGLE_ANALYTICS = ""

--- a/publishconf.py
+++ b/publishconf.py
@@ -7,7 +7,7 @@ sys.path.append('.')
 from pelicanconf import *
 
 DELETE_OUTPUT_DIRECTORY = True
-SITEURL = os.getenv('PELICAN_SITE_URL', 'https://beaverbarcamp.org')
+SITEURL = ''
 
 # Following items are often useful when publishing
 

--- a/publishconf.py
+++ b/publishconf.py
@@ -7,12 +7,12 @@ sys.path.append('.')
 from pelicanconf import *
 
 DELETE_OUTPUT_DIRECTORY = True
-SITEURL = os.getenv('PELICAN_SITE_URL', 'http://beaverbarcamp.org')
+SITEURL = os.getenv('PELICAN_SITE_URL', 'https://beaverbarcamp.org')
 
 # Following items are often useful when publishing
 
 # Uncomment following line for absolute URLs in production:
-RELATIVE_URLS = False
+#RELATIVE_URLS = False
 
 #DISQUS_SITENAME = ""
 #GOOGLE_ANALYTICS = ""


### PR DESCRIPTION
Relative URLs should make the website work no matter how you access it, so if you are using http or https it won't mismatch the URL in included images, CSS, etc.